### PR TITLE
Edickinson filter refinement

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/examples/community_birth.py
+++ b/examples/community_birth.py
@@ -4,7 +4,6 @@ from preql_nlp import build_query
 from preql.hooks.query_debugger import DebuggingHook
 from logging import StreamHandler, DEBUG
 from preql_nlp.constants import logger
-from preql.parsing.render import render_query
 
 logger.setLevel(DEBUG)
 logger.addHandler(StreamHandler())

--- a/examples/community_birth.py
+++ b/examples/community_birth.py
@@ -1,7 +1,6 @@
 from trilogy_public_models import models
 from preql import Dialects
 from preql_nlp import build_query
-from preql_nlp.main import parse_query
 from preql.hooks.query_debugger import DebuggingHook
 from logging import StreamHandler, DEBUG
 from preql_nlp.constants import logger
@@ -28,8 +27,8 @@ executor = Dialects.BIGQUERY.default_executor(
     environment=environment, hooks=[DebuggingHook()]
 )
 
-render_query(processed_query)
+# render_query(processed_query)
 
-results = executor.execute_query(processed_query)
-for row in results:
-    print(row)
+# results = executor.execute_query(processed_query)
+# for row in results:
+#     print(row)

--- a/examples/community_rendering.py
+++ b/examples/community_rendering.py
@@ -1,8 +1,5 @@
 from trilogy_public_models import models
-from preql import Dialects
-from preql_nlp import build_query
 from preql_nlp.main import parse_query
-from preql.hooks.query_debugger import DebuggingHook
 from logging import StreamHandler, DEBUG
 from preql_nlp.constants import logger
 from preql.parsing.render import render_query

--- a/examples/community_rendering.py
+++ b/examples/community_rendering.py
@@ -15,21 +15,10 @@ logger.addHandler(StreamHandler())
 environment = models["bigquery.usa_names"]
 
 
-processed_query = build_query(
-    "Most common names in the state of VT in 1990?",
+processed_query = parse_query(
+    "Most common names in Vermont in 1990?",
     environment,
     debug=True,
 )
 
-for key in processed_query.output_columns:
-    print(key)
-
-executor = Dialects.BIGQUERY.default_executor(
-    environment=environment, hooks=[DebuggingHook()]
-)
-
-render_query(processed_query)
-
-results = executor.execute_query(processed_query)
-for row in results:
-    print(row)
+print(render_query(processed_query))

--- a/examples/community_rendering.py
+++ b/examples/community_rendering.py
@@ -14,9 +14,11 @@ logger.addHandler(StreamHandler())
 # grab the model we want to parse
 environment = models["bigquery.usa_names"]
 
+environment.concepts['state'].metadata.description = 'The common two character abbreviation for a state, such as MA for Massachusetts or CT for Connecticut.'
+
 
 processed_query = parse_query(
-    "Most common names in Vermont in 1990?",
+    "What were the most common names in Vermont in 1990?",
     environment,
     debug=True,
 )

--- a/preql_nlp/__init__.py
+++ b/preql_nlp/__init__.py
@@ -5,6 +5,6 @@ patch_promptimize()
 from .main import build_query  # noqa: E402
 
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 __all__ = ["build_query"]

--- a/preql_nlp/main.py
+++ b/preql_nlp/main.py
@@ -17,7 +17,7 @@ from preql_nlp.prompts import (
     SemanticToTokensPromptCase,
     SelectionPromptCase,
     SemanticExtractionPromptCase,
-    FilterRefinementCase
+    FilterRefinementCase,
 )
 from preql_nlp.constants import logger, DEFAULT_LIMIT
 from preql_nlp.models import (
@@ -146,14 +146,16 @@ def discover_inputs(
 
     session_uuid = uuid.uuid4()
 
-    parsed: InitialParseResponse = run_prompt(
+    parsed: InitialParseResponse = run_prompt(  # type:ignore
         SemanticExtractionPromptCase(input_text),
         debug=debug,
         log_info=log_info,
         session_uuid=session_uuid,
     )
-    filtering =  build_token_list_by_purpose( concepts, (Purpose.METRIC, Purpose.KEY, Purpose.CONSTANT, Purpose.PROPERTY))
-    order = list(set(filtering+metrics+dimensions))
+    filtering = build_token_list_by_purpose(
+        concepts, (Purpose.METRIC, Purpose.KEY, Purpose.CONSTANT, Purpose.PROPERTY)
+    )
+    order = list(set(filtering + metrics + dimensions))
     token_inputs = TokenInputs(
         metrics=metrics, dimensions=dimensions, order=order, filtering=filtering
     )
@@ -162,10 +164,8 @@ def discover_inputs(
     for field in ["metrics", "dimensions", "filtering", "order"]:
         local_phrases = [get_phrase_from_x(x) for x in getattr(parsed, field)]
         all_tokens = getattr(token_inputs, field)
-        phrase_tokens: SemanticTokenResponse = run_prompt( # type: ignore
-            SemanticToTokensPromptCase(
-                phrases=local_phrases, tokens=all_tokens
-            ),
+        phrase_tokens: SemanticTokenResponse = run_prompt(  # type: ignore
+            SemanticToTokensPromptCase(phrases=local_phrases, tokens=all_tokens),
             debug=True,
             session_uuid=session_uuid,
             log_info=log_info,
@@ -180,18 +180,18 @@ def discover_inputs(
                     mapping.tokens,
                     [c for c in final_concept_list],
                     limits=5,
-                    universe=universe
+                    universe=universe,
                 )
                 if concepts:
                     logger.info(f"For phrase {mapping.phrase} got {concepts}")
                     output += concepts
-                    found=True
+                    found = True
                     break
             if not found:
                 raise ValueError(
                     f"Could not find concept for input {mapping.phrase} with tokens {mapping.tokens}"
                 )
-    selections: ConceptSelectionResponse = run_prompt( # type: ignore
+    selections: ConceptSelectionResponse = run_prompt(  # type: ignore
         SelectionPromptCase(concepts=output, question=input_text),
         debug=debug,
         session_uuid=session_uuid,
@@ -202,9 +202,14 @@ def discover_inputs(
     for item in parsed.filtering:
         instance = input_environment.concepts[item.concept]
         if instance.metadata:
-            item.values = run_prompt( # type: ignore
-                FilterRefinementCase(values=item.values,
-                                    description = instance.metadata.description )
+            item.values = run_prompt(  # type: ignore
+                FilterRefinementCase(
+                    values=item.values,
+                    description=instance.metadata.description,
+                ),
+                debug=debug,
+                session_uuid=session_uuid,
+                log_info=log_info,
             ).new_values
 
     return IntermediateParseResults(
@@ -252,8 +257,6 @@ def parse_order(
         if parsed:
             final.append(parsed)
     return OrderBy(items=final)
-
-
 
 
 def parse_filter(

--- a/preql_nlp/main.py
+++ b/preql_nlp/main.py
@@ -17,6 +17,7 @@ from preql_nlp.prompts import (
     SemanticToTokensPromptCase,
     SelectionPromptCase,
     SemanticExtractionPromptCase,
+    FilterRefinementCase
 )
 from preql_nlp.constants import logger, DEFAULT_LIMIT
 from preql_nlp.models import (
@@ -192,6 +193,14 @@ def discover_inputs(
         log_info=log_info,
     )
     final = list(set(selections.matches))
+
+    for item in parsed.filtering:
+        instance = input_environment.concepts[item.concept]
+        if instance.metadata:
+            item.concept = run_prompt( # type: ignore
+                FilterRefinementCase(value=item.concept,
+                                    description = instance.metadata.description )
+            ).new_value
 
     return IntermediateParseResults(
         select=final,

--- a/preql_nlp/models.py
+++ b/preql_nlp/models.py
@@ -36,7 +36,9 @@ class InitialParseResponse(BaseModel):
 
     @property
     def selection(self)->list[str]:
-        return self.metrics + self.dimensions
+        filtering = [f.concept for f in self.filtering]
+        order = [x.concept for x in self.order]
+        return self.metrics + self.dimensions + filtering + order
 
 
 class SemanticTokenMatch(BaseModel):
@@ -63,3 +65,8 @@ class IntermediateParseResults(BaseModel):
     limit: int
     order: list[OrderResult]
     filtering:list[FilterResult]
+
+
+class FilterRefinementResponse(BaseModel):
+    value:str
+    description:str

--- a/preql_nlp/models.py
+++ b/preql_nlp/models.py
@@ -68,6 +68,6 @@ class IntermediateParseResults(BaseModel):
 
 
 class FilterRefinementResponse(BaseModel):
-    new_value:str
-    original_value:str
-    description:str
+    new_values:list[str]
+    old_values:list[str]
+    reasoning:str

--- a/preql_nlp/models.py
+++ b/preql_nlp/models.py
@@ -68,5 +68,6 @@ class IntermediateParseResults(BaseModel):
 
 
 class FilterRefinementResponse(BaseModel):
-    value:str
+    new_value:str
+    original_value:str
     description:str

--- a/preql_nlp/prompts/__init__.py
+++ b/preql_nlp/prompts/__init__.py
@@ -1,2 +1,15 @@
-from .prompt_executor import run_prompt, SelectionPromptCase, SemanticExtractionPromptCase, SemanticToTokensPromptCase
-__all__ = ["run_prompt", "SelectionPromptCase", "SemanticExtractionPromptCase", "SemanticToTokensPromptCase"]
+from .prompt_executor import (
+    FilterRefinementCase,
+    SelectionPromptCase,
+    SemanticExtractionPromptCase,
+    SemanticToTokensPromptCase,
+    run_prompt,
+)
+
+__all__ = [
+    "run_prompt",
+    "SelectionPromptCase",
+    "SemanticExtractionPromptCase",
+    "SemanticToTokensPromptCase",
+    "FilterRefinementCase",
+]

--- a/preql_nlp/prompts/prompt_executor.py
+++ b/preql_nlp/prompts/prompt_executor.py
@@ -152,7 +152,7 @@ class SelectionPromptCase(BasePreqlPromptCase):
 
 
 class FilterRefinementCase(BasePreqlPromptCase):
-    template = templates.get_template('prompt_final_concepts.jinja2')
+    template = templates.get_template('prompt_refine_filter.jinja2')
     parse_model = FilterRefinementResponse
 
     attributes_used_for_hash = {"value", "description"}

--- a/preql_nlp/prompts/prompt_final_concepts.jinja2
+++ b/preql_nlp/prompts/prompt_final_concepts.jinja2
@@ -1,4 +1,3 @@
-SELECTION_TEMPLATE_V1 = """
 System: You are a helpful AI that selects the most relevant matching concepts to answer a question from a provided list.
 
 Guidelines:
@@ -25,5 +24,3 @@ System:
 "reasoning": "order.state is the best match for state, and order.revenue.avg would capture average revenue." }{% endraw %}
 User: concepts: [{{ concept_string }}] question: "{{ question }}"
 System:
-
-"""

--- a/preql_nlp/prompts/prompt_final_concepts.jinja2
+++ b/preql_nlp/prompts/prompt_final_concepts.jinja2
@@ -21,6 +21,6 @@ System:
 User: concepts: ["product.color", "order.state", "order.year", "order.revenue.sum", "order.revenue.avg", "product.name", "order.month", "order.day", "product.manufacturer"]  question: "What are the average sales by state?"
 System:
 {"matches": ["order.state", "order.revenue.avg"],
-"reasoning": "order.state is the best match for state, and order.revenue.avg would capture average revenue." }{% endraw %}
+"reasoning": "order.state is the best match for state, and order.revenue.avg references the average of revenue for an order, which is conceptually closest to sales." }{% endraw %}
 User: concepts: [{{ concept_string }}] question: "{{ question }}"
 System:

--- a/preql_nlp/prompts/prompt_query_semantic_groupings.jinja2
+++ b/preql_nlp/prompts/prompt_query_semantic_groupings.jinja2
@@ -1,6 +1,3 @@
-
-
-EXTRACTION_PROMPT_V1 = """
 System: You are a helpful AI that translates ambiguous business questions into structured outputs.
 For a provided question, you will determine if there are metrics or aggregates or dimensions,
 as well as any limit, order, or filtering. 
@@ -60,4 +57,3 @@ System:
 
 User: "{{ question }}"
 System:
-"""

--- a/preql_nlp/prompts/prompt_refine_filter.jinja2
+++ b/preql_nlp/prompts/prompt_refine_filter.jinja2
@@ -16,8 +16,8 @@ System:
 {% raw %}
 {"new_value": "VT",
 "old_value": "Vermont",
-"reasoning": "VT is the two letter state code for Vermont"}
+"reasoning": "VT is the two letter state code for Vermont"
+}
 {% endraw %}
-{%%} endraw %}
-User: Given the value {{ tokens }}, create the appropriate filter value for a field with the description:  [{{ phrase_str }}]
+User: Given the value {{ value }}, create the appropriate filter value for a field with the description: "{{ description }}"
 System:

--- a/preql_nlp/prompts/prompt_refine_filter.jinja2
+++ b/preql_nlp/prompts/prompt_refine_filter.jinja2
@@ -1,19 +1,18 @@
-System: you are an AI that rewrites a list of predicates that will be used to filter a SQL query based on some context on the field.
-You will transform the user input into a logically equivalent value formatted for the query given a description.
+System: you are an AI that transformas a list of values into a new format given a target description.
+You will transform the user input into new values which represent the intended format.
 
 Guidelines:
-- The input will be an array of predicates
-- Any special wrappers in a member of the array, such as the % character used in a SQL like clause, should be kept
-- The input value will be given to you as a list of values in quotes
-- The description of the field in the database will be provided in quotes after a ':' character
-- You will always return your best effort transformation
+- The input will be an array of values that may be in an incorrect format
+- The desired format description will be provided in quotes after a ':' character
+- Any special characters in the input, such as the % character used in a SQL like clause, should exist in the new value in the same location
+- You will always return your best effort transformation; if no change is needed or possible return the original value.
 
 You will output only a JSON formatted response with the following fields:
 * "new_values": an array of the transformed values
-* "old_values": the original value array you were given
+* "old_values": the original value array provided
 * "reasoning": a description of your logic 
 
-User: given the values ["Vermont", "Connecticut"], map to appropriate filter values for a field with the description: "Two character state code, ex MA for Massachusetts"
+User: given the values ["Vermont", "Connecticut"], transform to match the following description: "Two character state code, ex MA for Massachusetts"
 System:
 {% raw %}
 {"new_values": ["VT", "CT"],
@@ -21,7 +20,7 @@ System:
 "reasoning": "The field is described as containing states as two digit codes. VT is the two letter state code for Vermont and CT is the two letter state code for Connecticut"
 }
 {% endraw %}
-User: given the values ["100%", "75%"], map to appropriate filter values for a field with the description: "The percentage of survey respondents, expressed as a decimal between 0 and 1"
+User: given the values ["100%", "75%"], transform to match the following description: "The percentage of survey respondents, expressed as a decimal between 0 and 1"
 System:
 {% raw %}
 {"new_values": ["1.0", "0.75"],
@@ -29,7 +28,7 @@ System:
 "reasoning": "The description says the field is a decimal. The inputs were percents that need to be mapped to decimals between 0 and 1. I can remove the % sign and divide them by 100."
 }
 {% endraw %}
-User: given the values ["Blue", "Red"], map to appropriate filter values for a field with the description: "An integer enum of colors. 1 = RED, 2 = BLUE, 3 = GREEN, 4 = YELLOW "
+User: given the values ["Blue", "Red"], transform to match the following description: "An integer enum of colors. 1 = RED, 2 = BLUE, 3 = GREEN, 4 = YELLOW "
 System:
 {% raw %}
 {"new_values": [2, 1],
@@ -37,5 +36,5 @@ System:
 "reasoning": "Tthe field is described as an enum mapping integers to colors. Blue is described as mapping to 2, and red to 1."
 }
 {% endraw %}
-User: Given the values [{{ values }}], map to appropriate filter values for a field with the description: "{{ description }}"
+User: Given the values [{{ values }}], transform to match the following description: "{{ description }}"
 System:

--- a/preql_nlp/prompts/prompt_refine_filter.jinja2
+++ b/preql_nlp/prompts/prompt_refine_filter.jinja2
@@ -1,0 +1,23 @@
+System: you are an AI that refines rewrites a predicate to filter a SQL query based on some context on the field.
+
+Guidelines:
+- The predicate should be a valid SQL predicate, including any quotes
+- Any special wrappers, like % in a like clause, should be kept
+- The input value will be given to you in quotes
+- The description of the field in the database will be provided in quotes
+
+You will output a JSON formatted response with the following fields:
+* "new_value": the new format to use
+* "old_value": the original value you were given
+* "reasoning": a description of your logic
+
+User: given the value "Vermont", create the appropriate filter value for a field with the description: "Two character state code, ex MA for Massachusetts"
+System:
+{% raw %}
+{"new_value": "VT",
+"old_value": "Vermont",
+"reasoning": "VT is the two letter state code for Vermont"}
+{% endraw %}
+{%%} endraw %}
+User: Given the value {{ tokens }}, create the appropriate filter value for a field with the description:  [{{ phrase_str }}]
+System:

--- a/preql_nlp/prompts/prompt_refine_filter.jinja2
+++ b/preql_nlp/prompts/prompt_refine_filter.jinja2
@@ -1,23 +1,41 @@
-System: you are an AI that refines rewrites a predicate to filter a SQL query based on some context on the field.
+System: you are an AI that rewrites a list of predicates that will be used to filter a SQL query based on some context on the field.
+You will transform the user input into a logically equivalent value formatted for the query given a description.
 
 Guidelines:
-- The predicate should be a valid SQL predicate, including any quotes
-- Any special wrappers, like % in a like clause, should be kept
-- The input value will be given to you in quotes
-- The description of the field in the database will be provided in quotes
+- The input will be an array of predicates
+- Any special wrappers in a member of the array, such as the % character used in a SQL like clause, should be kept
+- The input value will be given to you as a list of values in quotes
+- The description of the field in the database will be provided in quotes after a ':' character
+- You will always return your best effort transformation
 
-You will output a JSON formatted response with the following fields:
-* "new_value": the new format to use
-* "old_value": the original value you were given
-* "reasoning": a description of your logic
+You will output only a JSON formatted response with the following fields:
+* "new_values": an array of the transformed values
+* "old_values": the original value array you were given
+* "reasoning": a description of your logic 
 
-User: given the value "Vermont", create the appropriate filter value for a field with the description: "Two character state code, ex MA for Massachusetts"
+User: given the values ["Vermont", "Connecticut"], map to appropriate filter values for a field with the description: "Two character state code, ex MA for Massachusetts"
 System:
 {% raw %}
-{"new_value": "VT",
-"old_value": "Vermont",
-"reasoning": "VT is the two letter state code for Vermont"
+{"new_values": ["VT", "CT"],
+"old_values": ["Vermont", "Connecticut"],
+"reasoning": "The field is described as containing states as two digit codes. VT is the two letter state code for Vermont and CT is the two letter state code for Connecticut"
 }
 {% endraw %}
-User: Given the value {{ value }}, create the appropriate filter value for a field with the description: "{{ description }}"
+User: given the values ["100%", "75%"], map to appropriate filter values for a field with the description: "The percentage of survey respondents, expressed as a decimal between 0 and 1"
+System:
+{% raw %}
+{"new_values": ["1.0", "0.75"],
+"old_values": ["100%", "75%"],
+"reasoning": "The description says the field is a decimal. The inputs were percents that need to be mapped to decimals between 0 and 1. I can remove the % sign and divide them by 100."
+}
+{% endraw %}
+User: given the values ["Blue", "Red"], map to appropriate filter values for a field with the description: "An integer enum of colors. 1 = RED, 2 = BLUE, 3 = GREEN, 4 = YELLOW "
+System:
+{% raw %}
+{"new_values": [2, 1],
+"old_values": ["Blue", "Red"],
+"reasoning": "Tthe field is described as an enum mapping integers to colors. Blue is described as mapping to 2, and red to 1."
+}
+{% endraw %}
+User: Given the values [{{ values }}], map to appropriate filter values for a field with the description: "{{ description }}"
 System:

--- a/preql_nlp/prompts/prompt_semantic_to_tokens.jinja2
+++ b/preql_nlp/prompts/prompt_semantic_to_tokens.jinja2
@@ -1,5 +1,3 @@
-
-STRUCTURED_PROMPT_V1 = """\
 System: you are an AI that helps a user map phrases to tokens by associating a phrase with tokens related to the words
 in the phrase.
 Guidelines:
@@ -66,5 +64,3 @@ System:
 ]{% endraw %}
 User: Given the tokens {{ tokens }}, match tokens to the phrases [{{ phrase_str }}]
 System:
-"""
-

--- a/preql_nlp/prompts/prompt_semantic_to_tokens.jinja2
+++ b/preql_nlp/prompts/prompt_semantic_to_tokens.jinja2
@@ -1,9 +1,9 @@
-System: you are an AI that helps a user map phrases to tokens by associating a phrase with tokens related to the words
+System: you are an AI that helps a user map phrases to tokens by associating a phrase with tokens most related to the words
 in the phrase.
 Guidelines:
 * you can assume the user will always provide a list of phrases
 * you can assume the user will always provide a list of tokens
-* only return tokens provided by the user
+* only return tokens that appear in the list provided by the user
 * If a phrase has no matches, return an empty array
 The output should be a VALID JSON list with each entry having the following keys
 * phrase, the input phrase
@@ -44,6 +44,16 @@ System:
       ]
    }   
 ]
+User: given the tokens ["product", "count", "order", "year"], match tokens to the phrases ["fairy_dust"]
+System:
+[
+   {
+      "phrase":"fairy_dust",
+      "tokens":[
+         "product"
+      ]
+   }
+]
 User: given the tokens ["product", "count", "order", "year"], match tokens to the phrases ["products sold", "orders"]
 System:
 [
@@ -62,5 +72,5 @@ System:
       ]
    }
 ]{% endraw %}
-User: Given the tokens {{ tokens }}, match tokens to the phrases [{{ phrase_str }}]
+User: Given the tokens [{{ tokens }}], match tokens to the phrases [{{ phrase_str }}]
 System:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         ]
     ),
     package_data={
-        "": ["*.tf", "*.jinja", "py.typed"],
+        "": ["*.tf", "*.jinja2", "py.typed"],
     },
     install_requires=install_requires,
     classifiers=[

--- a/tests/test_filter_refinement.py
+++ b/tests/test_filter_refinement.py
@@ -9,13 +9,22 @@ def gen_select_test(word):
 
     return [select_test]
 
-def test_filter_refinemnet():
+def test_filter_refinement():
     case1 = generate_test_case(
         FilterRefinementCase,
-        value="Vermont",
+        values=["California",],
         description="Field storing two digit state codes, ex MA for Massachusetts",
-        tests=gen_select_test("VT",
+        tests=gen_select_test(["CA",],
             
         ),
     )
-    evaluate_cases([case1])
+
+    case2 = generate_test_case(
+        FilterRefinementCase,
+        values=["95%",],
+        description="Field storing a float representing the percentage of the population that likes coconuts",
+        tests=gen_select_test([".95",],
+            
+        ),
+    )
+    evaluate_cases([case1, case2])

--- a/tests/test_filter_refinement.py
+++ b/tests/test_filter_refinement.py
@@ -1,0 +1,21 @@
+from preql_nlp.prompts.prompt_executor import FilterRefinementCase
+from preql_nlp.models import FilterRefinementResponse
+from tests.utility import generate_test_case, evaluate_cases
+
+
+def gen_select_test(word):
+    def select_test(x: FilterRefinementResponse):
+        return x.new_value == word
+
+    return [select_test]
+
+def test_filter_refinemnet():
+    case1 = generate_test_case(
+        FilterRefinementCase,
+        value="Vermont",
+        description="Field storing two digit state codes, ex MA for Massachusetts",
+        tests=gen_select_test("VT",
+            
+        ),
+    )
+    evaluate_cases([case1])

--- a/tests/test_filter_refinement.py
+++ b/tests/test_filter_refinement.py
@@ -3,9 +3,10 @@ from preql_nlp.models import FilterRefinementResponse
 from tests.utility import generate_test_case, evaluate_cases
 
 
-def gen_select_test(word):
+def gen_select_test(word:list[str]):
     def select_test(x: FilterRefinementResponse):
-        return x.new_value == word
+        print(x.new_values, word)
+        return x.new_values == word
 
     return [select_test]
 
@@ -13,7 +14,7 @@ def test_filter_refinement():
     case1 = generate_test_case(
         FilterRefinementCase,
         values=["California",],
-        description="Field storing two digit state codes, ex MA for Massachusetts",
+        description="The common two character abbreviation for a state, such as MA for Massachusetts or CT for Connecticut.",
         tests=gen_select_test(["CA",],
             
         ),
@@ -23,7 +24,7 @@ def test_filter_refinement():
         FilterRefinementCase,
         values=["95%",],
         description="Field storing a float representing the percentage of the population that likes coconuts",
-        tests=gen_select_test([".95",],
+        tests=gen_select_test(['0.95',],
             
         ),
     )

--- a/tests/test_relevant_phrase_extraction.py
+++ b/tests/test_relevant_phrase_extraction.py
@@ -10,14 +10,14 @@ def flatten_arg_list(obj, args):
         output += getattr(obj, arg)
     return output
 
+
 def coerce_list(item):
     if not isinstance(item, list):
         return [item]
     return item
 
+
 def validator_factory(key, test_values):
-
-
     def validator(input: InitialParseResponse, lkey=key, test_values=test_values):
         lkey = key
         ltest = coerce_list(test_values)
@@ -26,26 +26,33 @@ def validator_factory(key, test_values):
         check = all(
             [
                 any(
-                    (test == partial or (isinstance(partial, str) and test in partial)) for partial in field_values
+                    (test == partial or (isinstance(partial, str) and test in partial))
+                    for partial in field_values
                 )
                 for test in ltest
             ]
         )
         if not check:
-            raise ValueError("could not find ", test_values, " in ", key, " with ", field_values)
-            print(
+            raise ValueError(
                 "could not find ", test_values, " in ", key, " with ", field_values
             )
+            print("could not find ", test_values, " in ", key, " with ", field_values)
         return check
+
     return validator
+
 
 def gen_validate_initial_parse_result(**kwargs):
     outputs = []
-    for key, test_values in kwargs.items(): 
+    for key, test_values in kwargs.items():
         # CRITICAL
         # we need to assign the values here in the loop to defaults on the lambda
         # to avoid lazy binding
-        outputs.append( lambda x, test_values=test_values, key=key:  validator_factory(key, test_values)(x))
+        outputs.append(
+            lambda x, test_values=test_values, key=key: validator_factory(
+                key, test_values
+            )(x)
+        )
     return outputs
 
 
@@ -54,10 +61,7 @@ def test_extraction_prompt(test_logger):
         SemanticExtractionPromptCase,
         question="How many questions are asked per year? Order results by year desc",
         tests=gen_validate_initial_parse_result(
-            selection=[
-                "count",
-                "year"
-            ],
+            selection=["count", "year"],
             order=[OrderResult(concept="year", order=Ordering.DESCENDING)],
         ),
     )
@@ -79,8 +83,12 @@ def test_extraction_prompt(test_logger):
         SemanticExtractionPromptCase,
         question="50 most common names by count in the state of VT in the year 2010?",
         tests=gen_validate_initial_parse_result(
-            selection=["names", "count", "state", ],
-            limit = 50,
+            selection=[
+                "names",
+                "count",
+                "state",
+            ],
+            limit=50,
             filtering=[
                 FilterResult(
                     concept="year", values=["2010"], operator=ComparisonOperator.EQ
@@ -97,7 +105,7 @@ def test_extraction_prompt(test_logger):
         question="What were the 50 most common names by count in Vermont in the year 2010?",
         tests=gen_validate_initial_parse_result(
             selection=["name", "count", "state", "year"],
-            limit = 50,
+            limit=50,
             filtering=[
                 FilterResult(
                     concept="year", values=["2010"], operator=ComparisonOperator.EQ
@@ -110,16 +118,18 @@ def test_extraction_prompt(test_logger):
     )
     evaluate_cases([case1, case2, case3, case4])
 
+
 def test_like_predicates():
     case1 = generate_test_case(
         SemanticExtractionPromptCase,
         question="SO answers where the body contains the word jaguar?",
         tests=gen_validate_initial_parse_result(
-            selection=["answer", "body"],
-            limit = 50,
+            selection=["body"],
             filtering=[
                 FilterResult(
-                    concept="body", values=["%jaguar%"], operator=ComparisonOperator.EQ
+                    concept="body",
+                    values=["%jaguar%"],
+                    operator=ComparisonOperator.LIKE,
                 ),
             ],
         ),

--- a/tests/test_relevant_phrase_extraction.py
+++ b/tests/test_relevant_phrase_extraction.py
@@ -3,39 +3,49 @@ from preql_nlp.models import InitialParseResponse, FilterResult, OrderResult
 from tests.utility import generate_test_case, evaluate_cases
 from preql.core.enums import Ordering, ComparisonOperator
 
+
 def flatten_arg_list(obj, args):
     output = []
     for arg in args:
         output += getattr(obj, arg)
     return output
 
+def coerce_list(item):
+    if not isinstance(item, list):
+        return [item]
+    return item
+
+def validator_factory(key, test_values):
+
+
+    def validator(input: InitialParseResponse, lkey=key, test_values=test_values):
+        lkey = key
+        ltest = coerce_list(test_values)
+        field_values: list[str] = [x for x in coerce_list(getattr(input, lkey))]
+        # if all of the values appear in at least one of the sub phrases
+        check = all(
+            [
+                any(
+                    (test == partial or (isinstance(partial, str) and test in partial)) for partial in field_values
+                )
+                for test in ltest
+            ]
+        )
+        if not check:
+            raise ValueError("could not find ", test_values, " in ", key, " with ", field_values)
+            print(
+                "could not find ", test_values, " in ", key, " with ", field_values
+            )
+        return check
+    return validator
 
 def gen_validate_initial_parse_result(**kwargs):
     outputs = []
-    for key, test_values in kwargs.items():
-
-        def validator(input: InitialParseResponse):
-            # coerce any of the object results
-            # like filtering
-            # to a string for simplicity
-            #
-            field_values: list[str] = [x for x in getattr(input, key)]
-            # if all of the values appear in at least one of the sub phrases
-            check = all(
-                [
-                    any(
-                        (test in partial or test == partial) for partial in field_values
-                    )
-                    for test in test_values
-                ]
-            )
-            if not check:
-                print(
-                    "could not find ", test_values, " in ", key, " with ", field_values
-                )
-            return check
-
-        outputs.append(validator)
+    for key, test_values in kwargs.items(): 
+        # CRITICAL
+        # we need to assign the values here in the loop to defaults on the lambda
+        # to avoid lazy binding
+        outputs.append( lambda x, test_values=test_values, key=key:  validator_factory(key, test_values)(x))
     return outputs
 
 
@@ -45,10 +55,8 @@ def test_extraction_prompt(test_logger):
         question="How many questions are asked per year? Order results by year desc",
         tests=gen_validate_initial_parse_result(
             selection=[
-                "questions",
-                "asked",
-                "per",
-                "year",
+                "count",
+                "year"
             ],
             order=[OrderResult(concept="year", order=Ordering.DESCENDING)],
         ),
@@ -59,7 +67,61 @@ def test_extraction_prompt(test_logger):
         question="How many questions were asked in the year 2020?",
         tests=gen_validate_initial_parse_result(
             selection=["question", "count"],
-            filtering=[FilterResult(concept="year", values=["2020"], operator =ComparisonOperator.EQ)],
+            filtering=[
+                FilterResult(
+                    concept="year", values=["2020"], operator=ComparisonOperator.EQ
+                )
+            ],
         ),
     )
-    evaluate_cases([case1, case2])
+
+    case3 = generate_test_case(
+        SemanticExtractionPromptCase,
+        question="50 most common names by count in the state of VT in the year 2010?",
+        tests=gen_validate_initial_parse_result(
+            selection=["names", "count", "state", ],
+            limit = 50,
+            filtering=[
+                FilterResult(
+                    concept="year", values=["2010"], operator=ComparisonOperator.EQ
+                ),
+                FilterResult(
+                    concept="state", values=["VT"], operator=ComparisonOperator.EQ
+                ),
+            ],
+        ),
+    )
+
+    case4 = generate_test_case(
+        SemanticExtractionPromptCase,
+        question="What were the 50 most common names by count in Vermont in the year 2010?",
+        tests=gen_validate_initial_parse_result(
+            selection=["name", "count", "state", "year"],
+            limit = 50,
+            filtering=[
+                FilterResult(
+                    concept="year", values=["2010"], operator=ComparisonOperator.EQ
+                ),
+                FilterResult(
+                    concept="state", values=["Vermont"], operator=ComparisonOperator.EQ
+                ),
+            ],
+        ),
+    )
+    evaluate_cases([case1, case2, case3, case4])
+
+def test_like_predicates():
+    case1 = generate_test_case(
+        SemanticExtractionPromptCase,
+        question="SO answers where the body contains the word jaguar?",
+        tests=gen_validate_initial_parse_result(
+            selection=["answer", "body"],
+            limit = 50,
+            filtering=[
+                FilterResult(
+                    concept="body", values=["%jaguar%"], operator=ComparisonOperator.EQ
+                ),
+            ],
+        ),
+    )
+    evaluate_cases([case1])

--- a/tests/test_relevant_phrase_extraction.py
+++ b/tests/test_relevant_phrase_extraction.py
@@ -61,7 +61,7 @@ def test_extraction_prompt(test_logger):
         SemanticExtractionPromptCase,
         question="How many questions are asked per year? Order results by year desc",
         tests=gen_validate_initial_parse_result(
-            selection=["count", "year"],
+            selection=["question", "year"],
             order=[OrderResult(concept="year", order=Ordering.DESCENDING)],
         ),
     )
@@ -70,7 +70,7 @@ def test_extraction_prompt(test_logger):
         SemanticExtractionPromptCase,
         question="How many questions were asked in the year 2020?",
         tests=gen_validate_initial_parse_result(
-            selection=["question", "count"],
+            selection=["question"],
             filtering=[
                 FilterResult(
                     concept="year", values=["2020"], operator=ComparisonOperator.EQ

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -14,8 +14,7 @@ def generate_test_case(
     evaluators = []
     evaluators.append(lambda x: prompt.parse_model.parse_raw(x) is not None)
     for idx, test in enumerate(tests):
-        evaluators.append(lambda x, idx=idx, test=test: test(prompt.parse_model.parse_raw(x)) )
-
+        evaluators.append(lambda x, idx=idx, test=test: test(prompt.parse_model.parse_raw(x)) ) # type: ignore
 
     case = prompt(
         **kwargs,

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -6,11 +6,6 @@ from typing import List, Callable
 from pydantic import BaseModel
 
 
-def validate_model(input:BaseModel, accessor:Callable[[BaseModel], List[str]], matches: List[str])->bool:
-    field_vals = accessor(input)
-    success = all([any(x in field for field in field_vals) for x in matches])
-    return success
-
 def generate_test_case(
     prompt: BasePreqlPromptCase,
     tests:List[Callable[[BaseModel], bool]],
@@ -18,8 +13,10 @@ def generate_test_case(
 ):
     evaluators = []
     evaluators.append(lambda x: prompt.parse_model.parse_raw(x) is not None)
-    for test in tests:
-        evaluators.append(lambda x: test(prompt.parse_model.parse_raw(x)) )
+    for idx, test in enumerate(tests):
+        evaluators.append(lambda x, idx=idx, test=test: test(prompt.parse_model.parse_raw(x)) )
+
+
     case = prompt(
         **kwargs,
         evaluators=evaluators,
@@ -43,7 +40,6 @@ def evaluate_cases(cases:List[BasePreqlPromptCase]):
         # limit=limit,
     )
     output_report = Report.from_suite(suite)
-
     # print results to log
     print(serialize_object(output_report.data.to_dict(), highlighted=False, style="yaml"))
     # print(output_report.print_summary())


### PR DESCRIPTION
This enables refinement of filter values based on the description provided for a concept.

Ex: if the user provides 'Alabama' as an input and the concept is described as a 'two character  state abbreviation', the value should be remapped to AL. 

Misc changes:
- Turn prompts into jinja template files
- Make prompt hashing for cache more deterministic
- Fix lots of testing issues