### PR TITLE
Edickinson "Trust in the LLM"

### DIFF
--- a/examples/community_so.py
+++ b/examples/community_so.py
@@ -13,7 +13,7 @@ environment = models["bigquery.stack_overflow"]
 
 
 processed_query = parse_query(
-    "How many questions tagged as python have been asked by users in Germany?",
+    "How many questions were asked on Christmas day 2013?",
     environment,
     debug=True,
 )

--- a/preql_nlp/__init__.py
+++ b/preql_nlp/__init__.py
@@ -5,6 +5,6 @@ patch_promptimize()
 from .main import build_query  # noqa: E402
 
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 __all__ = ["build_query"]

--- a/preql_nlp/main.py
+++ b/preql_nlp/main.py
@@ -19,7 +19,6 @@ from preql.core.query_processor import process_query_v2
 
 from preql_nlp.constants import DEFAULT_LIMIT, logger
 from preql_nlp.models import (
-    ConceptSelectionResponse,
     FilterResult,
     FinalFilterResult,
     FinalOrderResult,

--- a/preql_nlp/main.py
+++ b/preql_nlp/main.py
@@ -119,8 +119,7 @@ def discover_inputs(
     # LLM: semantic extraction
     # LLM: tokenization of all strings (reduce search space over all concepts)
     # DETERMINISTIC: concept candidates from tokens (map reduced search space to candidates)
-    # LLM: final selection of concepts (final get the concept result we want)
-    # DETERMINISTIC: map phrases to final concepts
+    # LLM: final selection of concepts and mapping to output roles
     # LLM: enrich filter values
     # DETERMINISTIC: return results
 

--- a/preql_nlp/models.py
+++ b/preql_nlp/models.py
@@ -41,6 +41,14 @@ class InitialParseResponse(BaseModel):
         return list(set(self.metrics + self.dimensions + filtering + order))
 
 
+class FinalParseResponse(BaseModel):
+    """The result of the initial parse"""
+    selection:list[str]
+    limit:int
+    order:list[OrderResult]
+    filtering:list[FilterResult]
+
+
 class IntermediateParseResults(BaseModel):
     select: list[Concept]
     limit: int

--- a/preql_nlp/prompts/prompt_final_concepts.jinja2
+++ b/preql_nlp/prompts/prompt_final_concepts.jinja2
@@ -1,8 +1,9 @@
 System: You are a helpful AI that selects the most relevant matching concepts to answer a question from a provided list.
 
 Guidelines:
-* you can assume the user will always provide a list of phrases
-* you can assume the user will always provide a question
+* the user will always provide a list of phrases
+* the user will always provide a question
+* the user may provide some filters they wish to use
 * only return concepts provided by the user
 * concepts are dot seperated and in quotes, e.g. "sales" or "product.revenue"
 * return the concepts that together best match the user question
@@ -10,18 +11,22 @@ Guidelines:
 The output should be a VALID JSON blob with the following keys and values:
 * matches: a list of concepts from the user provided list that together best match the 
 * reasoning: a string explaining your step by step reasoning for the matches
+* final_filters: the filters remapped to the restricted concepts
 
-User: concepts: ["product.color", "order.state", "order.year", "order.revenue.sum", "order.revenue.avg", "product.name", "order.month", "order.day", "product.manufacturer"] question: "what color products were the top sellers by revenue in 2024?"]
+User: concepts: ["product.color", "order.state", "order.year", "order.revenue.sum", "order.revenue.avg", "product.name", "order.month", "order.day", "product.manufacturer"] question: "what color products were the top sellers by revenue in 2024?"
 System:
 {% raw %}{"matches": ["product.color", "order.revenue.sum", "order.year" ],
-"reasoning": "product.color matches the user request for product colors, and order revenue sum would enable aggregating revenue to the color to determine the top. Order year is required to filter to 2024." }
-User: concepts: ["product.color", "order.state", "order.year", "order.revenue.sum", "order.revenue.avg", "product.name", "order.month", "order.day", "product.manufacturer"] question: "What are the sales by state?"
-System:
+final_filters:[{"order.year": "2024"}],
+"reasoning": "product.color matches the user request for product colors, and order revenue sum would enable aggregating revenue to the color to determine the top. Order year is required to filter to 2024." }{% endraw %}
+User: concepts: ["product.color", "order.state", "order.year", "order.revenue.sum", "order.revenue.avg", "product.name", "order.month", "order.day", "product.manufacturer"] question: "What are the sales by state? No filtering."
+System:{% raw %}
 {"matches": ["order.state", "order.revenue.sum"],
-"reasoning": "order.state is the best match for state when looking at revenue, and order.revenue.sum would enable aggregating revenue." }
-User: concepts: ["product.color", "order.state", "order.year", "order.revenue.sum", "order.revenue.avg", "product.name", "order.month", "order.day", "product.manufacturer"]  question: "What are the average sales by state?"
-System:
+"final_filters": [],
+"reasoning": "order.state is the best match for state when looking at revenue, and order.revenue.sum would enable aggregating revenue." }{% endraw %}
+User: concepts: ["product.color", "order.state", "order.year", "order.revenue.sum", "order.revenue.avg", "product.name", "order.month", "order.day", "product.manufacturer"]  question: "What are the average sales by state? No filtering."
+System:{% raw %}
 {"matches": ["order.state", "order.revenue.avg"],
+"final_filters": [],
 "reasoning": "order.state is the best match for state, and order.revenue.avg references the average of revenue for an order, which is conceptually closest to sales." }{% endraw %}
-User: concepts: [{{ concept_string }}] question: "{{ question }}"
+User: concepts: [{{ concept_string }}] question: "{{ question }}" {%if filtering%}Filter by {{filtering}}{% else %}No filtering{% endif%}
 System:

--- a/preql_nlp/prompts/prompt_final_concepts_v2.jinja2
+++ b/preql_nlp/prompts/prompt_final_concepts_v2.jinja2
@@ -1,0 +1,70 @@
+System: You are a helpful AI that selects the most relevant matching concepts to answer a question from a provided list.
+
+Guidelines:
+* the user will always provide a list of phrases
+* the user will always provide a question
+* the user may provide some filters they wish to use
+* only return concepts provided by the user
+* concepts are dot seperated and in quotes, e.g. "sales" or "product.revenue"
+* return the concepts that together best match the user question
+* reason about each match step by step, e.g. "first match the concept 'product' to the word 'product' in the question, then match the concept 'revenue' to the word 'revenue' in the question, and together these enable aggregating revenue by year"
+
+
+The output should be a VALID JSON blob with the following keys and values followed by {{ stopword }}:
+- selection: a list of concepts that together can completely answer the question in a way understandable to a human
+- limit: a number of records to limit the results to, -1 if none specified
+- order: a list of  objects to order the results by, with the option to specify ascending or descending
+-- concept: a concept to order by
+-- order: the direction of ordering, "asc" or "desc"
+- filtering: a list of objects to filter the results on, where each object has the following keys:
+-- concept: a concept to filter on
+-- values: the value the concept is filtered to
+-- operator: the comparison operator, one of "=", "in", "<", ">", "<=", "like", or ">=". A range, or between, should be expressed as two inequalities. 
+
+User: concepts: ["people.id", "people.id.count", "people.favorite_color", "people.age", "people.gender", "activity.id", "activity.name", "activity.date", "activity.date.year", "activity.date.month", "activity.date.day_of_week"] question: "How many people who love the color pink played frisbee on saturday??"
+System:
+{% raw %}{
+"selection": ["people.id.count", "people.favorite_color", "activity.name", "activity.date.day_of_week"],
+"limit": -1,
+"order": [],
+"filtering": [{"concept":"people.favorite_color", "operator": "=", "values":["Pink"]}, {"concept":"activity.date.day_of_week", "operator": "=", "values":["Saturday"]}, {"concept":"activity.name", "operator": "=", "values":["frisbee"]}]
+}{% endraw %}{{ stopword }},
+
+User: concepts: ["order.source", "order.source.line_of_business", "order.customer.id", "order.customer.state", "order.revenue", "order.revenue.sum", "order.id", "order.date", "product.id", "product.name", "product.color", "product.brand"] question: "What are the top 10 products by sales?"
+System:
+{% raw %}{
+"selection": ["product.id", "product.name", "order.revenue.sum"]
+"limit": 10,
+"order": [{"concept":"order.revenue.sum", "order":"desc"}],
+"filtering": []
+}{% endraw %}{{ stopword }}
+
+User: concepts: ["order.source", "order.source.line_of_business", "order.customer.id", "order.customer.state", "order.revenue", "order.revenue.sum", "order.revenue.avg", "order.id", "order.date", "product.id", "product.name", "product.color", "product.brand"] question: "What are the sales by line of business and state?"
+System:{% raw %}
+{
+"selection": ["order.revenue.sum", "order.source.line_of_business", "order.customer.state"],
+"limit": -1,
+"order": [],
+"filtering": []
+}{% endraw %}{{ stopword }}
+
+User: concepts: ["order.source", "order.source.line_of_business", "order.customer.id", "order.customer.state", "order.revenue", "order.revenue.sum", "order.revenue.avg", "order.id", "order.date", "product.id", "product.name", "product.color", "product.brand"]  question: "What is the average sales by state in the states of Wyoming and Texas?"
+System:{% raw %}
+{
+"selection": ["order.customer.state", "order.revenue.avg"],
+"limit": -1,
+"order": [],
+"filtering": [{"concept":"order.customer.state", "operator": "in", "values":["Wyoming", "Texas"]}]
+}{% endraw %}{{ stopword }}
+
+User: concepts: ["order.source", "order.source.line_of_business", "order.customer.id", "order.customer.state", "order.revenue", "order.revenue.sum", "order.revenue.avg", "order.id", "order.date", "order.date.year", "product.id", "product.revenue_rank.yearly", "product.name", "product.color", "product.brand"]  question: "What were top selling products between 2001 and 2020 in order of year?"
+System:{% raw %}
+{
+"selection": ["product.id", "product.name", "order.revenue.sum", "product.revenue_rank.yearly"],
+"limit": -1,
+"order": [{"concept":"order.date.year", "order":"asc"}],
+"filtering": [{"concept": "product.revenue_rank.yearly", "operator": "<", "values":[10]},{"concept":"order.year", "operator":">=", "values":["2001"]}, {"concept":"order.year", "operator":"<=", "values":["2020"]}]
+}{% endraw %}{{ stopword }}
+
+User: concepts: [{{concept_string}}] question: "{{ question }}"
+System:

--- a/preql_nlp/prompts/prompt_semantic_to_tokens.jinja2
+++ b/preql_nlp/prompts/prompt_semantic_to_tokens.jinja2
@@ -1,18 +1,20 @@
 System: you are a helpful AI that maps a list of phrases to the most related words from a provided set. Multiple
-words can related to a phrase, but you should not include any that have no relation at all.
+words can related to a phrase, but if there are several similar terms include only the most specific one. If Multiple
+terms are related to the phrase but not similar, include both. If a phrase has no matches, return an empty array.
 
 Guidelines:
-* you can assume the user will always provide a list of phrases
-* you can assume the user will always provide a list of words
+* the user will always provide a list of phrases
+* the user will always provide a list of words
+* the user will provide a purpose for the phrase
 * only return words that appear in the list provided by the user
 * If a phrase has no matches, return an empty array
 The output should be a VALID JSON list. Each JSON list entry should have following keys.
 * phrase, the input phrase
 * tokens, the user provided words that are most related to the phrase
-The full ohutput should be followed by {{stopword}}.
+The full output should be followed by {{stopword}}.
 
 
-User: given the words ["color", "product", "year", "revenue"], find the most relevant words for each phrase in ["product revenue is up", "products with green color", "product revenue by year", "yearly revenue"]
+User: given the words ["color", "product", "year", "revenue", "count"], find the most relevant words for the purpose of creating metrics for each phrase in ["product revenue is up", "products with green color", "product revenue by year", "yearly revenue"]
 System:
 {% raw %}
 [
@@ -27,7 +29,8 @@ System:
       "phrase":"product color",
       "tokens":[
          "product",
-         "color"
+         "color",
+         "count"
       ]
     },
     {
@@ -46,19 +49,35 @@ System:
       ]
    }   
 ]{% endraw %}{{ stopword }}
-User: given the words ["state", "motto", "taxes", "expenses"], find the most relevant words for each phrase in ["vermont budget shortfall "]
+User: given the words ["state", "motto", "taxes", "expenses"], find the most relevant words for the purpose of filtering for each phrase in ["vermont budget shortfall "]
 System:{% raw %}
 [
    {
       "phrase":"vermont budget shortfall",
       "tokens":[
-         "state",
-         "taxes",
-         "expenses"
+         "state"
       ]
    }
 ]{% endraw %}{{ stopword }}
-User: given the words ["product", "count", "order", "year"], find the most relevant words for each phrase in ["top selling products", "order flow"]
+User: given the words ["product", "color", "revenue", "skus"], find the most relevant words for the purpose of grouping data for each phrase in ["products by color", "SKUs by color"]
+System:{% raw %}
+[
+   {
+      "phrase":"products by color",
+      "tokens":[
+         "products",
+         "color"
+      ]
+   },
+      {
+      "phrase":"skus by color",
+      "tokens":[
+         "skus",
+         "color"
+      ]
+   }
+]{% endraw %}{{ stopword }}
+User: given the words ["product", "count", "order", "year"], find the most relevant words for the purpose of metrics for each phrase in ["top selling products", "order flow"]
 System:{% raw %}
 [
    {
@@ -77,5 +96,5 @@ System:{% raw %}
       ]
    }
 ]{% endraw %}{{ stopword }}
-User: Given the words [{{ tokens }}], find the most relevant words for each phrase in [{{ phrase_str }}]
+User: Given the words [{{ tokens }}], find the most relevant words for the purpose of {{purpose}} for each phrase in [{{ phrase_str }}]
 System:

--- a/preql_nlp/tokenization.py
+++ b/preql_nlp/tokenization.py
@@ -41,16 +41,12 @@ def tokens_to_concept(
     mappings = {x: split_to_tokens(x) for x in concepts}
     candidates =[x for x in concepts if any(token in mappings[x] for token in tokens)]
     pickings = defaultdict(list)
-    log = 'count' in tokens
 
     if not candidates:
         return None
     tiers = set()
 
     for candidate in candidates:
-        # print('scoring')
-        # print(candidate)
-        # print("---")
         score  = 0
         candidate_tokens = mappings[candidate]
         # exact match to concept is +2
@@ -66,29 +62,13 @@ def tokens_to_concept(
         pickings[score].append(candidate)
         tiers.add(score)
     tier_list = sorted(list(tiers), key=lambda x: -x)
-    if log:
-        print('FOR TOKENS')
-        print(tokens)
-        print('in universe')
-        print(universe_list)
-        print('candidates are')
-    for key, value in pickings.items():
-        candidates = sorted(value, key=lambda x: len(x))
-        if log:
-            print('----')
-            print(key)
-        for match in candidates:
-            if log:
-                print(match)
     found: List[str] = []
     while len(found) < limits and tier_list:
 
         stier = tier_list.pop(0)
-        candidates = sorted(pickings[stier], key=lambda x: len(x))
+        # sort within list by length ascending, then alphabetical
+        # for consistency
+        candidates = sorted(pickings[stier], key=lambda x: (len(x), x))
         required = limits - len(found)
         found += candidates[:required]
-    if log:
-        print('FINAL RETURN IS')
-        print('xxxxx')
-        print(found)
     return found

--- a/preql_nlp/tokenization.py
+++ b/preql_nlp/tokenization.py
@@ -41,25 +41,45 @@ def tokens_to_concept(
     mappings = {x: split_to_tokens(x) for x in concepts}
     candidates =[x for x in concepts if any(token in mappings[x] for token in tokens)]
     pickings = defaultdict(list)
+    log = 'count' in tokens
 
     if not candidates:
         return None
     tiers = set()
-    
+
     for candidate in candidates:
+        # print('scoring')
+        # print(candidate)
+        # print("---")
         score  = 0
         candidate_tokens = mappings[candidate]
         # exact match to concept is +2
-        for x in candidate_tokens:
-            if x in tokens:
-                score +=2
+        for x in tokens:
+            if x in candidate_tokens:
+                # print(f'+2 score from token {x} in candidate list')
+                score +=10
         # universe context is + 1
         for y in universe_list:
-            if y in tokens:
+            if y in candidate_tokens:
+                # print(f"+1 score from token {y} in universe")
                 score +=1
         pickings[score].append(candidate)
         tiers.add(score)
     tier_list = sorted(list(tiers), key=lambda x: -x)
+    if log:
+        print('FOR TOKENS')
+        print(tokens)
+        print('in universe')
+        print(universe_list)
+        print('candidates are')
+    for key, value in pickings.items():
+        candidates = sorted(value, key=lambda x: len(x))
+        if log:
+            print('----')
+            print(key)
+        for match in candidates:
+            if log:
+                print(match)
     found: List[str] = []
     while len(found) < limits and tier_list:
 
@@ -67,4 +87,8 @@ def tokens_to_concept(
         candidates = sorted(pickings[stier], key=lambda x: len(x))
         required = limits - len(found)
         found += candidates[:required]
+    if log:
+        print('FINAL RETURN IS')
+        print('xxxxx')
+        print(found)
     return found

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -7,6 +7,7 @@ def test_retry():
     test = SemanticToTokensPromptCase(
         tokens=["alphabet", "soup", "apple", "fruit", "shape", "orange"],
         phrases=["round fruits"],
+        purpose = "Dimension"
     )
 
     test.execute_prompt = (

--- a/tests/test_phrase_to_concepts.py
+++ b/tests/test_phrase_to_concepts.py
@@ -1,12 +1,15 @@
 from preql_nlp.prompts.prompt_executor import SelectionPromptCase
-from preql_nlp.models import ConceptSelectionResponse
+from preql_nlp.models import FinalParseResponse
 from tests.utility import generate_test_case, evaluate_cases
 
 
-def gen_select_test(words):
-    def select_test(x: ConceptSelectionResponse):
-        return set(x.matches) == set(words)
-
+def gen_select_test(words, filters:list[str] | None = None):
+    def select_test(x: FinalParseResponse):
+        return set(x.selection) == set(words)
+    if filters:
+        def filter_test(x:FinalParseResponse):
+            return set([z.concept for z in x.filtering]) == set(filters)
+        return [select_test, filter_test]
     return [select_test]
 
 
@@ -25,7 +28,7 @@ def test_selection_prompt(test_logger):
 
     test2 = generate_test_case(
         SelectionPromptCase,
-        tests=gen_select_test(["question.author", "question.id"]),
+        tests=gen_select_test(["question.author"], ["question.id"]),
         question="Author of question id 2?",
         concept_names=[
             "question.creation_date.year",

--- a/tests/test_semantic_to_tokens.py
+++ b/tests/test_semantic_to_tokens.py
@@ -25,6 +25,7 @@ def test_structured_input():
         tests=gen_semantic_tests({first_phrase: ["question", "year", "count"]}),
         phrases=[first_phrase],
         tokens=["question", "year", "count", "albatross", "answer", "month", "quarter"],
+        purpose = 'Metric'
     )
 
     evaluate_cases([test1])

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,35 @@
+from preql_nlp.tokenization import tokens_to_concept
+
+
+def test_tokens_to_concept():
+    x = tokens_to_concept(
+        ["date", "year", "time"],
+        ["answer.creation.date", "answer.creation.date.year"],
+        universe=["answer"],
+        limits=1,
+    )
+    assert x == ["answer.creation.date.year"]
+
+    x = tokens_to_concept(
+        ["timestamp", "second", "time", "hour", "date", "minute"],
+        [
+            "badge.awarded_time",
+            "badge.awarded_date",
+            "answer.creation_date",
+            "question.creation_date",
+        ],
+        universe=[
+            "month",
+            "timestamp",
+            "second",
+            "time",
+            "hour",
+            "count",
+            "date",
+            "minute",
+            "year",
+            "question",
+        ],
+        limits = 1
+    )
+    assert x == ["question.creation_date"]


### PR DESCRIPTION
Redo our final selection to stop trying to match concepts back to phrases and just prompt the LLM to use the reduced concept list it generated to produce the structured outputs. 

This removes a step, resulting in
``` 
   # DETERMINSTIC: setup logging
    # LLM: semantic extraction
    # LLM: tokenization of all strings (reduce search space over all concepts)
    # DETERMINISTIC: concept candidates from tokens (map reduced search space to candidates)
    # LLM: final selection of concepts and mapping to output roles
    # LLM: enrich filter values
    # DETERMINISTIC: return results```